### PR TITLE
Increase maximum volume to 150%

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,7 +103,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ serverAPI }) => {
         }
         return (
           <PanelSectionRow>
-            <SliderField bottomSeparator="none" min={0} max={1} step={0.05} value={sinkInput.volume} label={label}
+            <SliderField bottomSeparator="none" min={0} max={1.5} step={0.05} value={sinkInput.volume} label={label}
               disabled={!sinkInput.index} description={sinkInput.codec} onChange={(volume) => setInputVolume(sinkInput.index, volume)} />
             {sinkInput.device &&
               <Focusable style={{ display: 'flex', alignItems: 'center', gap: '1rem' }} flow-children="horizontal">


### PR DESCRIPTION
Hullo there, thank you for the making this plugin. I use it almost daily! 

Would you consider increasing the maximum value on the volume sliders to 150%? We can do this even from the desktop, and it would really help with those stubborn games that are too quiet for no reason—or namely, Discord.

I have been using the following manual change on my install, and it's been working without any problems. 
```js
	window.SP_REACT.createElement(deckyFrontendLib.SliderField, { bottomSeparator: "none", min: 0, max: 1.5, step: 0.05, value: sinkInput.volume, label: label, disabled: !sinkInput.index, description:
```

Of course, if we should keep the default 100% and add a setting somewhere to turn on 150%, that'd also be great!